### PR TITLE
Upgrade terraform-provider-duplocloud to v0.12.14

### DIFF
--- a/provider/cmd/pulumi-resource-duplocloud/schema.json
+++ b/provider/cmd/pulumi-resource-duplocloud/schema.json
@@ -53858,6 +53858,10 @@
                     },
                     "description": "Helm chart\n"
                 },
+                "forceUpdate": {
+                    "type": "boolean",
+                    "description": "When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.\n"
+                },
                 "interval": {
                     "type": "string",
                     "description": "Interval related to helm release Defaults to `5m0s`.\n"
@@ -53893,6 +53897,10 @@
                     },
                     "description": "Helm chart\n",
                     "willReplaceOnChanges": true
+                },
+                "forceUpdate": {
+                    "type": "boolean",
+                    "description": "When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.\n"
                 },
                 "interval": {
                     "type": "string",
@@ -53933,6 +53941,10 @@
                         },
                         "description": "Helm chart\n",
                         "willReplaceOnChanges": true
+                    },
+                    "forceUpdate": {
+                        "type": "boolean",
+                        "description": "When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.\n"
                     },
                     "interval": {
                         "type": "string",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250124205414-92ccb3765401
 
 require (
-	github.com/duplocloud/terraform-provider-duplocloud v0.12.13
+	github.com/duplocloud/terraform-provider-duplocloud v0.12.14
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.102.0
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1522,8 +1522,8 @@ github.com/deckarep/golang-set/v2 v2.5.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpO
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/duplocloud/terraform-provider-duplocloud v0.12.13 h1:fgT73zXXfHomhz3Gjd+f7v97ZkdWPdIVVWmJftrCRG4=
-github.com/duplocloud/terraform-provider-duplocloud v0.12.13/go.mod h1:5pUbnUCoHbmqmkN3i1FYTI0G0XLJxNf5TOKWET8yxns=
+github.com/duplocloud/terraform-provider-duplocloud v0.12.14 h1:S08atfWNfZjiYi2ElxeIAoLvaWqi7lijkRtARxFsgIs=
+github.com/duplocloud/terraform-provider-duplocloud v0.12.14/go.mod h1:5pUbnUCoHbmqmkN3i1FYTI0G0XLJxNf5TOKWET8yxns=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=

--- a/sdk/dotnet/K8HelmRelease.cs
+++ b/sdk/dotnet/K8HelmRelease.cs
@@ -84,6 +84,12 @@ namespace DuploCloud.Pulumi
         public Output<ImmutableArray<Outputs.K8HelmReleaseChart>> Charts { get; private set; } = null!;
 
         /// <summary>
+        /// When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+        /// </summary>
+        [Output("forceUpdate")]
+        public Output<bool?> ForceUpdate { get; private set; } = null!;
+
+        /// <summary>
         /// Interval related to helm release Defaults to `5m0s`.
         /// </summary>
         [Output("interval")]
@@ -173,6 +179,12 @@ namespace DuploCloud.Pulumi
         }
 
         /// <summary>
+        /// When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+        /// </summary>
+        [Input("forceUpdate")]
+        public Input<bool>? ForceUpdate { get; set; }
+
+        /// <summary>
         /// Interval related to helm release Defaults to `5m0s`.
         /// </summary>
         [Input("interval")]
@@ -221,6 +233,12 @@ namespace DuploCloud.Pulumi
             get => _charts ?? (_charts = new InputList<Inputs.K8HelmReleaseChartGetArgs>());
             set => _charts = value;
         }
+
+        /// <summary>
+        /// When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+        /// </summary>
+        [Input("forceUpdate")]
+        public Input<bool>? ForceUpdate { get; set; }
 
         /// <summary>
         /// Interval related to helm release Defaults to `5m0s`.

--- a/sdk/go/duplocloud/k8helmRelease.go
+++ b/sdk/go/duplocloud/k8helmRelease.go
@@ -90,6 +90,8 @@ type K8HelmRelease struct {
 
 	// Helm chart
 	Charts K8HelmReleaseChartArrayOutput `pulumi:"charts"`
+	// When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+	ForceUpdate pulumi.BoolPtrOutput `pulumi:"forceUpdate"`
 	// Interval related to helm release Defaults to `5m0s`.
 	Interval pulumi.StringPtrOutput `pulumi:"interval"`
 	// The name of the helm chart
@@ -143,6 +145,8 @@ func GetK8HelmRelease(ctx *pulumi.Context,
 type k8helmReleaseState struct {
 	// Helm chart
 	Charts []K8HelmReleaseChart `pulumi:"charts"`
+	// When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+	ForceUpdate *bool `pulumi:"forceUpdate"`
 	// Interval related to helm release Defaults to `5m0s`.
 	Interval *string `pulumi:"interval"`
 	// The name of the helm chart
@@ -158,6 +162,8 @@ type k8helmReleaseState struct {
 type K8HelmReleaseState struct {
 	// Helm chart
 	Charts K8HelmReleaseChartArrayInput
+	// When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+	ForceUpdate pulumi.BoolPtrInput
 	// Interval related to helm release Defaults to `5m0s`.
 	Interval pulumi.StringPtrInput
 	// The name of the helm chart
@@ -177,6 +183,8 @@ func (K8HelmReleaseState) ElementType() reflect.Type {
 type k8helmReleaseArgs struct {
 	// Helm chart
 	Charts []K8HelmReleaseChart `pulumi:"charts"`
+	// When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+	ForceUpdate *bool `pulumi:"forceUpdate"`
 	// Interval related to helm release Defaults to `5m0s`.
 	Interval *string `pulumi:"interval"`
 	// The name of the helm chart
@@ -193,6 +201,8 @@ type k8helmReleaseArgs struct {
 type K8HelmReleaseArgs struct {
 	// Helm chart
 	Charts K8HelmReleaseChartArrayInput
+	// When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+	ForceUpdate pulumi.BoolPtrInput
 	// Interval related to helm release Defaults to `5m0s`.
 	Interval pulumi.StringPtrInput
 	// The name of the helm chart
@@ -295,6 +305,11 @@ func (o K8HelmReleaseOutput) ToK8HelmReleaseOutputWithContext(ctx context.Contex
 // Helm chart
 func (o K8HelmReleaseOutput) Charts() K8HelmReleaseChartArrayOutput {
 	return o.ApplyT(func(v *K8HelmRelease) K8HelmReleaseChartArrayOutput { return v.Charts }).(K8HelmReleaseChartArrayOutput)
+}
+
+// When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+func (o K8HelmReleaseOutput) ForceUpdate() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *K8HelmRelease) pulumi.BoolPtrOutput { return v.ForceUpdate }).(pulumi.BoolPtrOutput)
 }
 
 // Interval related to helm release Defaults to `5m0s`.

--- a/sdk/nodejs/k8helmRelease.ts
+++ b/sdk/nodejs/k8helmRelease.ts
@@ -87,6 +87,10 @@ export class K8HelmRelease extends pulumi.CustomResource {
      */
     public readonly charts!: pulumi.Output<outputs.K8HelmReleaseChart[]>;
     /**
+     * When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+     */
+    public readonly forceUpdate!: pulumi.Output<boolean | undefined>;
+    /**
      * Interval related to helm release Defaults to `5m0s`.
      */
     public readonly interval!: pulumi.Output<string | undefined>;
@@ -121,6 +125,7 @@ export class K8HelmRelease extends pulumi.CustomResource {
         if (opts.id) {
             const state = argsOrState as K8HelmReleaseState | undefined;
             resourceInputs["charts"] = state ? state.charts : undefined;
+            resourceInputs["forceUpdate"] = state ? state.forceUpdate : undefined;
             resourceInputs["interval"] = state ? state.interval : undefined;
             resourceInputs["name"] = state ? state.name : undefined;
             resourceInputs["releaseName"] = state ? state.releaseName : undefined;
@@ -138,6 +143,7 @@ export class K8HelmRelease extends pulumi.CustomResource {
                 throw new Error("Missing required property 'tenantId'");
             }
             resourceInputs["charts"] = args ? args.charts : undefined;
+            resourceInputs["forceUpdate"] = args ? args.forceUpdate : undefined;
             resourceInputs["interval"] = args ? args.interval : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["releaseName"] = args ? args.releaseName : undefined;
@@ -157,6 +163,10 @@ export interface K8HelmReleaseState {
      * Helm chart
      */
     charts?: pulumi.Input<pulumi.Input<inputs.K8HelmReleaseChart>[]>;
+    /**
+     * When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+     */
+    forceUpdate?: pulumi.Input<boolean>;
     /**
      * Interval related to helm release Defaults to `5m0s`.
      */
@@ -187,6 +197,10 @@ export interface K8HelmReleaseArgs {
      * Helm chart
      */
     charts: pulumi.Input<pulumi.Input<inputs.K8HelmReleaseChart>[]>;
+    /**
+     * When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+     */
+    forceUpdate?: pulumi.Input<boolean>;
     /**
      * Interval related to helm release Defaults to `5m0s`.
      */

--- a/sdk/python/pulumi_duplocloud/k8_helm_release.py
+++ b/sdk/python/pulumi_duplocloud/k8_helm_release.py
@@ -24,6 +24,7 @@ class K8HelmReleaseArgs:
                  charts: pulumi.Input[Sequence[pulumi.Input['K8HelmReleaseChartArgs']]],
                  release_name: pulumi.Input[str],
                  tenant_id: pulumi.Input[str],
+                 force_update: Optional[pulumi.Input[bool]] = None,
                  interval: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  values: Optional[pulumi.Input[str]] = None):
@@ -32,6 +33,7 @@ class K8HelmReleaseArgs:
         :param pulumi.Input[Sequence[pulumi.Input['K8HelmReleaseChartArgs']]] charts: Helm chart
         :param pulumi.Input[str] release_name: Provide release name to identify specific deployment of helm chart.
         :param pulumi.Input[str] tenant_id: The GUID of the tenant that the storage bucket will be created in.
+        :param pulumi.Input[bool] force_update: When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
         :param pulumi.Input[str] interval: Interval related to helm release Defaults to `5m0s`.
         :param pulumi.Input[str] name: The name of the helm chart
         :param pulumi.Input[str] values: Customise an helm chart.
@@ -39,6 +41,8 @@ class K8HelmReleaseArgs:
         pulumi.set(__self__, "charts", charts)
         pulumi.set(__self__, "release_name", release_name)
         pulumi.set(__self__, "tenant_id", tenant_id)
+        if force_update is not None:
+            pulumi.set(__self__, "force_update", force_update)
         if interval is not None:
             pulumi.set(__self__, "interval", interval)
         if name is not None:
@@ -83,6 +87,18 @@ class K8HelmReleaseArgs:
         pulumi.set(self, "tenant_id", value)
 
     @property
+    @pulumi.getter(name="forceUpdate")
+    def force_update(self) -> Optional[pulumi.Input[bool]]:
+        """
+        When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+        """
+        return pulumi.get(self, "force_update")
+
+    @force_update.setter
+    def force_update(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "force_update", value)
+
+    @property
     @pulumi.getter
     def interval(self) -> Optional[pulumi.Input[str]]:
         """
@@ -123,6 +139,7 @@ class K8HelmReleaseArgs:
 class _K8HelmReleaseState:
     def __init__(__self__, *,
                  charts: Optional[pulumi.Input[Sequence[pulumi.Input['K8HelmReleaseChartArgs']]]] = None,
+                 force_update: Optional[pulumi.Input[bool]] = None,
                  interval: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  release_name: Optional[pulumi.Input[str]] = None,
@@ -131,6 +148,7 @@ class _K8HelmReleaseState:
         """
         Input properties used for looking up and filtering K8HelmRelease resources.
         :param pulumi.Input[Sequence[pulumi.Input['K8HelmReleaseChartArgs']]] charts: Helm chart
+        :param pulumi.Input[bool] force_update: When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
         :param pulumi.Input[str] interval: Interval related to helm release Defaults to `5m0s`.
         :param pulumi.Input[str] name: The name of the helm chart
         :param pulumi.Input[str] release_name: Provide release name to identify specific deployment of helm chart.
@@ -139,6 +157,8 @@ class _K8HelmReleaseState:
         """
         if charts is not None:
             pulumi.set(__self__, "charts", charts)
+        if force_update is not None:
+            pulumi.set(__self__, "force_update", force_update)
         if interval is not None:
             pulumi.set(__self__, "interval", interval)
         if name is not None:
@@ -161,6 +181,18 @@ class _K8HelmReleaseState:
     @charts.setter
     def charts(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['K8HelmReleaseChartArgs']]]]):
         pulumi.set(self, "charts", value)
+
+    @property
+    @pulumi.getter(name="forceUpdate")
+    def force_update(self) -> Optional[pulumi.Input[bool]]:
+        """
+        When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+        """
+        return pulumi.get(self, "force_update")
+
+    @force_update.setter
+    def force_update(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "force_update", value)
 
     @property
     @pulumi.getter
@@ -229,6 +261,7 @@ class K8HelmRelease(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  charts: Optional[pulumi.Input[Sequence[pulumi.Input[Union['K8HelmReleaseChartArgs', 'K8HelmReleaseChartArgsDict']]]]] = None,
+                 force_update: Optional[pulumi.Input[bool]] = None,
                  interval: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  release_name: Optional[pulumi.Input[str]] = None,
@@ -285,6 +318,7 @@ class K8HelmRelease(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Sequence[pulumi.Input[Union['K8HelmReleaseChartArgs', 'K8HelmReleaseChartArgsDict']]]] charts: Helm chart
+        :param pulumi.Input[bool] force_update: When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
         :param pulumi.Input[str] interval: Interval related to helm release Defaults to `5m0s`.
         :param pulumi.Input[str] name: The name of the helm chart
         :param pulumi.Input[str] release_name: Provide release name to identify specific deployment of helm chart.
@@ -360,6 +394,7 @@ class K8HelmRelease(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  charts: Optional[pulumi.Input[Sequence[pulumi.Input[Union['K8HelmReleaseChartArgs', 'K8HelmReleaseChartArgsDict']]]]] = None,
+                 force_update: Optional[pulumi.Input[bool]] = None,
                  interval: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  release_name: Optional[pulumi.Input[str]] = None,
@@ -377,6 +412,7 @@ class K8HelmRelease(pulumi.CustomResource):
             if charts is None and not opts.urn:
                 raise TypeError("Missing required property 'charts'")
             __props__.__dict__["charts"] = charts
+            __props__.__dict__["force_update"] = force_update
             __props__.__dict__["interval"] = interval
             __props__.__dict__["name"] = name
             if release_name is None and not opts.urn:
@@ -397,6 +433,7 @@ class K8HelmRelease(pulumi.CustomResource):
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
             charts: Optional[pulumi.Input[Sequence[pulumi.Input[Union['K8HelmReleaseChartArgs', 'K8HelmReleaseChartArgsDict']]]]] = None,
+            force_update: Optional[pulumi.Input[bool]] = None,
             interval: Optional[pulumi.Input[str]] = None,
             name: Optional[pulumi.Input[str]] = None,
             release_name: Optional[pulumi.Input[str]] = None,
@@ -410,6 +447,7 @@ class K8HelmRelease(pulumi.CustomResource):
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Sequence[pulumi.Input[Union['K8HelmReleaseChartArgs', 'K8HelmReleaseChartArgsDict']]]] charts: Helm chart
+        :param pulumi.Input[bool] force_update: When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
         :param pulumi.Input[str] interval: Interval related to helm release Defaults to `5m0s`.
         :param pulumi.Input[str] name: The name of the helm chart
         :param pulumi.Input[str] release_name: Provide release name to identify specific deployment of helm chart.
@@ -421,6 +459,7 @@ class K8HelmRelease(pulumi.CustomResource):
         __props__ = _K8HelmReleaseState.__new__(_K8HelmReleaseState)
 
         __props__.__dict__["charts"] = charts
+        __props__.__dict__["force_update"] = force_update
         __props__.__dict__["interval"] = interval
         __props__.__dict__["name"] = name
         __props__.__dict__["release_name"] = release_name
@@ -435,6 +474,14 @@ class K8HelmRelease(pulumi.CustomResource):
         Helm chart
         """
         return pulumi.get(self, "charts")
+
+    @property
+    @pulumi.getter(name="forceUpdate")
+    def force_update(self) -> pulumi.Output[Optional[bool]]:
+        """
+        When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
+        """
+        return pulumi.get(self, "force_update")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider duplocloud/pulumi-duplocloud --kind=provider --target-bridge-version=latest --target-version=0.12.14 --allow-missing-docs=true`.

---

- Upgrading terraform-provider-duplocloud from 0.12.13  to 0.12.14.
	Fixes #48
