### PR TITLE
Upgrade terraform-provider-duplocloud to v0.12.15

### DIFF
--- a/provider/cmd/pulumi-resource-duplocloud/schema.json
+++ b/provider/cmd/pulumi-resource-duplocloud/schema.json
@@ -19160,6 +19160,10 @@
                     "type": "boolean",
                     "description": "Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.\n"
                 },
+                "k8sWorkerOs": {
+                    "type": "string",
+                    "description": "OS type for k8s worker. Valid values: `Linux`, `Windows`.\n"
+                },
                 "lbSyncedDeployment": {
                     "type": "boolean"
                 },
@@ -19219,6 +19223,7 @@
                 "hpaSpecs",
                 "isDaemonset",
                 "isUniqueK8sNodeRequired",
+                "k8sWorkerOs",
                 "lbSyncedDeployment",
                 "name",
                 "otherDockerConfig",
@@ -47552,7 +47557,7 @@
                 },
                 "k8sWorkerOs": {
                     "type": "string",
-                    "description": "OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`\n"
+                    "description": "OS type for k8s worker. Valid values: `Linux`, `Windows`.\n"
                 },
                 "lbSyncedDeployment": {
                     "type": "boolean"
@@ -47680,7 +47685,7 @@
                 },
                 "k8sWorkerOs": {
                     "type": "string",
-                    "description": "OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`\n",
+                    "description": "OS type for k8s worker. Valid values: `Linux`, `Windows`.\n",
                     "willReplaceOnChanges": true
                 },
                 "lbSyncedDeployment": {
@@ -47807,7 +47812,7 @@
                     },
                     "k8sWorkerOs": {
                         "type": "string",
-                        "description": "OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`\n",
+                        "description": "OS type for k8s worker. Valid values: `Linux`, `Windows`.\n",
                         "willReplaceOnChanges": true
                     },
                     "lbSyncedDeployment": {
@@ -59618,6 +59623,10 @@
                         "description": "Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.\n",
                         "type": "boolean"
                     },
+                    "k8sWorkerOs": {
+                        "description": "OS type for k8s worker. Valid values: `Linux`, `Windows`.\n",
+                        "type": "string"
+                    },
                     "lbSyncedDeployment": {
                         "type": "boolean"
                     },
@@ -59676,6 +59685,7 @@
                     "hpaSpecs",
                     "isDaemonset",
                     "isUniqueK8sNodeRequired",
+                    "k8sWorkerOs",
                     "lbSyncedDeployment",
                     "name",
                     "otherDockerConfig",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250124205414-92ccb3765401
 
 require (
-	github.com/duplocloud/terraform-provider-duplocloud v0.12.14
+	github.com/duplocloud/terraform-provider-duplocloud v0.12.15
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.102.0
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1522,8 +1522,8 @@ github.com/deckarep/golang-set/v2 v2.5.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpO
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/duplocloud/terraform-provider-duplocloud v0.12.14 h1:S08atfWNfZjiYi2ElxeIAoLvaWqi7lijkRtARxFsgIs=
-github.com/duplocloud/terraform-provider-duplocloud v0.12.14/go.mod h1:5pUbnUCoHbmqmkN3i1FYTI0G0XLJxNf5TOKWET8yxns=
+github.com/duplocloud/terraform-provider-duplocloud v0.12.15 h1:6VVJAPihzXIhbaEqEM9aT8Ndw2ccLknaKHekcCuMjEE=
+github.com/duplocloud/terraform-provider-duplocloud v0.12.15/go.mod h1:5pUbnUCoHbmqmkN3i1FYTI0G0XLJxNf5TOKWET8yxns=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=

--- a/sdk/dotnet/DuploService.cs
+++ b/sdk/dotnet/DuploService.cs
@@ -588,7 +588,7 @@ namespace DuploCloud.Pulumi
         public Output<bool?> IsUniqueK8sNodeRequired { get; private set; } = null!;
 
         /// <summary>
-        /// OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+        /// OS type for k8s worker. Valid values: `Linux`, `Windows`.
         /// </summary>
         [Output("k8sWorkerOs")]
         public Output<string?> K8sWorkerOs { get; private set; } = null!;
@@ -785,7 +785,7 @@ namespace DuploCloud.Pulumi
         public Input<bool>? IsUniqueK8sNodeRequired { get; set; }
 
         /// <summary>
-        /// OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+        /// OS type for k8s worker. Valid values: `Linux`, `Windows`.
         /// </summary>
         [Input("k8sWorkerOs")]
         public Input<string>? K8sWorkerOs { get; set; }
@@ -958,7 +958,7 @@ namespace DuploCloud.Pulumi
         public Input<bool>? IsUniqueK8sNodeRequired { get; set; }
 
         /// <summary>
-        /// OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+        /// OS type for k8s worker. Valid values: `Linux`, `Windows`.
         /// </summary>
         [Input("k8sWorkerOs")]
         public Input<string>? K8sWorkerOs { get; set; }

--- a/sdk/dotnet/GetDuploService.cs
+++ b/sdk/dotnet/GetDuploService.cs
@@ -86,6 +86,10 @@ namespace DuploCloud.Pulumi
         /// Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
         /// </summary>
         public readonly bool IsUniqueK8sNodeRequired;
+        /// <summary>
+        /// OS type for k8s worker. Valid values: `Linux`, `Windows`.
+        /// </summary>
+        public readonly string K8sWorkerOs;
         public readonly bool LbSyncedDeployment;
         public readonly string Name;
         public readonly string OtherDockerConfig;
@@ -139,6 +143,8 @@ namespace DuploCloud.Pulumi
 
             bool isUniqueK8sNodeRequired,
 
+            string k8sWorkerOs,
+
             bool lbSyncedDeployment,
 
             string name,
@@ -179,6 +185,7 @@ namespace DuploCloud.Pulumi
             Id = id;
             IsDaemonset = isDaemonset;
             IsUniqueK8sNodeRequired = isUniqueK8sNodeRequired;
+            K8sWorkerOs = k8sWorkerOs;
             LbSyncedDeployment = lbSyncedDeployment;
             Name = name;
             OtherDockerConfig = otherDockerConfig;

--- a/sdk/dotnet/Outputs/GetDuploServicesServiceResult.cs
+++ b/sdk/dotnet/Outputs/GetDuploServicesServiceResult.cs
@@ -41,6 +41,10 @@ namespace DuploCloud.Pulumi.Outputs
         /// Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
         /// </summary>
         public readonly bool IsUniqueK8sNodeRequired;
+        /// <summary>
+        /// OS type for k8s worker. Valid values: `Linux`, `Windows`.
+        /// </summary>
+        public readonly string K8sWorkerOs;
         public readonly bool LbSyncedDeployment;
         public readonly string Name;
         public readonly string OtherDockerConfig;
@@ -92,6 +96,8 @@ namespace DuploCloud.Pulumi.Outputs
 
             bool isUniqueK8sNodeRequired,
 
+            string k8sWorkerOs,
+
             bool lbSyncedDeployment,
 
             string name,
@@ -131,6 +137,7 @@ namespace DuploCloud.Pulumi.Outputs
             HpaSpecs = hpaSpecs;
             IsDaemonset = isDaemonset;
             IsUniqueK8sNodeRequired = isUniqueK8sNodeRequired;
+            K8sWorkerOs = k8sWorkerOs;
             LbSyncedDeployment = lbSyncedDeployment;
             Name = name;
             OtherDockerConfig = otherDockerConfig;

--- a/sdk/go/duplocloud/duploService.go
+++ b/sdk/go/duplocloud/duploService.go
@@ -630,7 +630,7 @@ type DuploService struct {
 	IsDaemonset pulumi.BoolPtrOutput `pulumi:"isDaemonset"`
 	// Whether or not the replicas must be scheduled on separate Kubernetes nodes. Only supported on Kubernetes.
 	IsUniqueK8sNodeRequired pulumi.BoolPtrOutput `pulumi:"isUniqueK8sNodeRequired"`
-	// OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+	// OS type for k8s worker. Valid values: `Linux`, `Windows`.
 	K8sWorkerOs        pulumi.StringPtrOutput `pulumi:"k8sWorkerOs"`
 	LbSyncedDeployment pulumi.BoolPtrOutput   `pulumi:"lbSyncedDeployment"`
 	// The name of the service to create.
@@ -726,7 +726,7 @@ type duploServiceState struct {
 	IsDaemonset *bool `pulumi:"isDaemonset"`
 	// Whether or not the replicas must be scheduled on separate Kubernetes nodes. Only supported on Kubernetes.
 	IsUniqueK8sNodeRequired *bool `pulumi:"isUniqueK8sNodeRequired"`
-	// OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+	// OS type for k8s worker. Valid values: `Linux`, `Windows`.
 	K8sWorkerOs        *string `pulumi:"k8sWorkerOs"`
 	LbSyncedDeployment *bool   `pulumi:"lbSyncedDeployment"`
 	// The name of the service to create.
@@ -787,7 +787,7 @@ type DuploServiceState struct {
 	IsDaemonset pulumi.BoolPtrInput
 	// Whether or not the replicas must be scheduled on separate Kubernetes nodes. Only supported on Kubernetes.
 	IsUniqueK8sNodeRequired pulumi.BoolPtrInput
-	// OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+	// OS type for k8s worker. Valid values: `Linux`, `Windows`.
 	K8sWorkerOs        pulumi.StringPtrInput
 	LbSyncedDeployment pulumi.BoolPtrInput
 	// The name of the service to create.
@@ -844,7 +844,7 @@ type duploServiceArgs struct {
 	IsDaemonset *bool `pulumi:"isDaemonset"`
 	// Whether or not the replicas must be scheduled on separate Kubernetes nodes. Only supported on Kubernetes.
 	IsUniqueK8sNodeRequired *bool `pulumi:"isUniqueK8sNodeRequired"`
-	// OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+	// OS type for k8s worker. Valid values: `Linux`, `Windows`.
 	K8sWorkerOs        *string `pulumi:"k8sWorkerOs"`
 	LbSyncedDeployment *bool   `pulumi:"lbSyncedDeployment"`
 	// The name of the service to create.
@@ -895,7 +895,7 @@ type DuploServiceArgs struct {
 	IsDaemonset pulumi.BoolPtrInput
 	// Whether or not the replicas must be scheduled on separate Kubernetes nodes. Only supported on Kubernetes.
 	IsUniqueK8sNodeRequired pulumi.BoolPtrInput
-	// OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+	// OS type for k8s worker. Valid values: `Linux`, `Windows`.
 	K8sWorkerOs        pulumi.StringPtrInput
 	LbSyncedDeployment pulumi.BoolPtrInput
 	// The name of the service to create.
@@ -1098,7 +1098,7 @@ func (o DuploServiceOutput) IsUniqueK8sNodeRequired() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *DuploService) pulumi.BoolPtrOutput { return v.IsUniqueK8sNodeRequired }).(pulumi.BoolPtrOutput)
 }
 
-// OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+// OS type for k8s worker. Valid values: `Linux`, `Windows`.
 func (o DuploServiceOutput) K8sWorkerOs() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *DuploService) pulumi.StringPtrOutput { return v.K8sWorkerOs }).(pulumi.StringPtrOutput)
 }

--- a/sdk/go/duplocloud/getDuploService.go
+++ b/sdk/go/duplocloud/getDuploService.go
@@ -49,11 +49,13 @@ type LookupDuploServiceResult struct {
 	Id          string `pulumi:"id"`
 	IsDaemonset bool   `pulumi:"isDaemonset"`
 	// Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
-	IsUniqueK8sNodeRequired bool   `pulumi:"isUniqueK8sNodeRequired"`
-	LbSyncedDeployment      bool   `pulumi:"lbSyncedDeployment"`
-	Name                    string `pulumi:"name"`
-	OtherDockerConfig       string `pulumi:"otherDockerConfig"`
-	OtherDockerHostConfig   string `pulumi:"otherDockerHostConfig"`
+	IsUniqueK8sNodeRequired bool `pulumi:"isUniqueK8sNodeRequired"`
+	// OS type for k8s worker. Valid values: `Linux`, `Windows`.
+	K8sWorkerOs           string `pulumi:"k8sWorkerOs"`
+	LbSyncedDeployment    bool   `pulumi:"lbSyncedDeployment"`
+	Name                  string `pulumi:"name"`
+	OtherDockerConfig     string `pulumi:"otherDockerConfig"`
+	OtherDockerHostConfig string `pulumi:"otherDockerHostConfig"`
 	// The service's parent domain
 	ParentDomain              string `pulumi:"parentDomain"`
 	ReplicaCollocationAllowed bool   `pulumi:"replicaCollocationAllowed"`
@@ -167,6 +169,11 @@ func (o LookupDuploServiceResultOutput) IsDaemonset() pulumi.BoolOutput {
 // Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
 func (o LookupDuploServiceResultOutput) IsUniqueK8sNodeRequired() pulumi.BoolOutput {
 	return o.ApplyT(func(v LookupDuploServiceResult) bool { return v.IsUniqueK8sNodeRequired }).(pulumi.BoolOutput)
+}
+
+// OS type for k8s worker. Valid values: `Linux`, `Windows`.
+func (o LookupDuploServiceResultOutput) K8sWorkerOs() pulumi.StringOutput {
+	return o.ApplyT(func(v LookupDuploServiceResult) string { return v.K8sWorkerOs }).(pulumi.StringOutput)
 }
 
 func (o LookupDuploServiceResultOutput) LbSyncedDeployment() pulumi.BoolOutput {

--- a/sdk/go/duplocloud/pulumiTypes1.go
+++ b/sdk/go/duplocloud/pulumiTypes1.go
@@ -35497,11 +35497,13 @@ type GetDuploServicesService struct {
 	HpaSpecs    string `pulumi:"hpaSpecs"`
 	IsDaemonset bool   `pulumi:"isDaemonset"`
 	// Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
-	IsUniqueK8sNodeRequired bool   `pulumi:"isUniqueK8sNodeRequired"`
-	LbSyncedDeployment      bool   `pulumi:"lbSyncedDeployment"`
-	Name                    string `pulumi:"name"`
-	OtherDockerConfig       string `pulumi:"otherDockerConfig"`
-	OtherDockerHostConfig   string `pulumi:"otherDockerHostConfig"`
+	IsUniqueK8sNodeRequired bool `pulumi:"isUniqueK8sNodeRequired"`
+	// OS type for k8s worker. Valid values: `Linux`, `Windows`.
+	K8sWorkerOs           string `pulumi:"k8sWorkerOs"`
+	LbSyncedDeployment    bool   `pulumi:"lbSyncedDeployment"`
+	Name                  string `pulumi:"name"`
+	OtherDockerConfig     string `pulumi:"otherDockerConfig"`
+	OtherDockerHostConfig string `pulumi:"otherDockerHostConfig"`
 	// The service's parent domain
 	ParentDomain              string `pulumi:"parentDomain"`
 	ReplicaCollocationAllowed bool   `pulumi:"replicaCollocationAllowed"`
@@ -35544,11 +35546,13 @@ type GetDuploServicesServiceArgs struct {
 	HpaSpecs    pulumi.StringInput `pulumi:"hpaSpecs"`
 	IsDaemonset pulumi.BoolInput   `pulumi:"isDaemonset"`
 	// Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
-	IsUniqueK8sNodeRequired pulumi.BoolInput   `pulumi:"isUniqueK8sNodeRequired"`
-	LbSyncedDeployment      pulumi.BoolInput   `pulumi:"lbSyncedDeployment"`
-	Name                    pulumi.StringInput `pulumi:"name"`
-	OtherDockerConfig       pulumi.StringInput `pulumi:"otherDockerConfig"`
-	OtherDockerHostConfig   pulumi.StringInput `pulumi:"otherDockerHostConfig"`
+	IsUniqueK8sNodeRequired pulumi.BoolInput `pulumi:"isUniqueK8sNodeRequired"`
+	// OS type for k8s worker. Valid values: `Linux`, `Windows`.
+	K8sWorkerOs           pulumi.StringInput `pulumi:"k8sWorkerOs"`
+	LbSyncedDeployment    pulumi.BoolInput   `pulumi:"lbSyncedDeployment"`
+	Name                  pulumi.StringInput `pulumi:"name"`
+	OtherDockerConfig     pulumi.StringInput `pulumi:"otherDockerConfig"`
+	OtherDockerHostConfig pulumi.StringInput `pulumi:"otherDockerHostConfig"`
 	// The service's parent domain
 	ParentDomain              pulumi.StringInput `pulumi:"parentDomain"`
 	ReplicaCollocationAllowed pulumi.BoolInput   `pulumi:"replicaCollocationAllowed"`
@@ -35674,6 +35678,11 @@ func (o GetDuploServicesServiceOutput) IsDaemonset() pulumi.BoolOutput {
 // Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
 func (o GetDuploServicesServiceOutput) IsUniqueK8sNodeRequired() pulumi.BoolOutput {
 	return o.ApplyT(func(v GetDuploServicesService) bool { return v.IsUniqueK8sNodeRequired }).(pulumi.BoolOutput)
+}
+
+// OS type for k8s worker. Valid values: `Linux`, `Windows`.
+func (o GetDuploServicesServiceOutput) K8sWorkerOs() pulumi.StringOutput {
+	return o.ApplyT(func(v GetDuploServicesService) string { return v.K8sWorkerOs }).(pulumi.StringOutput)
 }
 
 func (o GetDuploServicesServiceOutput) LbSyncedDeployment() pulumi.BoolOutput {

--- a/sdk/nodejs/duploService.ts
+++ b/sdk/nodejs/duploService.ts
@@ -431,7 +431,7 @@ export class DuploService extends pulumi.CustomResource {
      */
     public readonly isUniqueK8sNodeRequired!: pulumi.Output<boolean | undefined>;
     /**
-     * OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+     * OS type for k8s worker. Valid values: `Linux`, `Windows`.
      */
     public readonly k8sWorkerOs!: pulumi.Output<string | undefined>;
     public readonly lbSyncedDeployment!: pulumi.Output<boolean | undefined>;
@@ -631,7 +631,7 @@ export interface DuploServiceState {
      */
     isUniqueK8sNodeRequired?: pulumi.Input<boolean>;
     /**
-     * OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+     * OS type for k8s worker. Valid values: `Linux`, `Windows`.
      */
     k8sWorkerOs?: pulumi.Input<string>;
     lbSyncedDeployment?: pulumi.Input<boolean>;
@@ -725,7 +725,7 @@ export interface DuploServiceArgs {
      */
     isUniqueK8sNodeRequired?: pulumi.Input<boolean>;
     /**
-     * OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+     * OS type for k8s worker. Valid values: `Linux`, `Windows`.
      */
     k8sWorkerOs?: pulumi.Input<string>;
     lbSyncedDeployment?: pulumi.Input<boolean>;

--- a/sdk/nodejs/getDuploService.ts
+++ b/sdk/nodejs/getDuploService.ts
@@ -57,6 +57,10 @@ export interface GetDuploServiceResult {
      * Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
      */
     readonly isUniqueK8sNodeRequired: boolean;
+    /**
+     * OS type for k8s worker. Valid values: `Linux`, `Windows`.
+     */
+    readonly k8sWorkerOs: string;
     readonly lbSyncedDeployment: boolean;
     readonly name: string;
     readonly otherDockerConfig: string;

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -4270,6 +4270,10 @@ export interface GetDuploServicesService {
      * Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
      */
     isUniqueK8sNodeRequired: boolean;
+    /**
+     * OS type for k8s worker. Valid values: `Linux`, `Windows`.
+     */
+    k8sWorkerOs: string;
     lbSyncedDeployment: boolean;
     name: string;
     otherDockerConfig: string;

--- a/sdk/python/pulumi_duplocloud/duplo_service.py
+++ b/sdk/python/pulumi_duplocloud/duplo_service.py
@@ -64,7 +64,7 @@ class DuploServiceArgs:
         :param pulumi.Input[Sequence[pulumi.Input['DuploServiceInitContainerDockerImageArgs']]] init_container_docker_images: The docker images to use for the launched init container(s).
         :param pulumi.Input[bool] is_daemonset: Whether or not to enable DaemonSet.
         :param pulumi.Input[bool] is_unique_k8s_node_required: Whether or not the replicas must be scheduled on separate Kubernetes nodes. Only supported on Kubernetes.
-        :param pulumi.Input[str] k8s_worker_os: OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+        :param pulumi.Input[str] k8s_worker_os: OS type for k8s worker. Valid values: `Linux`, `Windows`.
         :param pulumi.Input[str] name: The name of the service to create.
         :param pulumi.Input[bool] replica_collocation_allowed: Allow replica collocation for the service. If this is set then 2 replicas can be on the same host.
         :param pulumi.Input[int] replicas: The number of container replicas to deploy.
@@ -309,7 +309,7 @@ class DuploServiceArgs:
     @pulumi.getter(name="k8sWorkerOs")
     def k8s_worker_os(self) -> Optional[pulumi.Input[str]]:
         """
-        OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+        OS type for k8s worker. Valid values: `Linux`, `Windows`.
         """
         return pulumi.get(self, "k8s_worker_os")
 
@@ -469,7 +469,7 @@ class _DuploServiceState:
         :param pulumi.Input[Sequence[pulumi.Input['DuploServiceInitContainerDockerImageArgs']]] init_container_docker_images: The docker images to use for the launched init container(s).
         :param pulumi.Input[bool] is_daemonset: Whether or not to enable DaemonSet.
         :param pulumi.Input[bool] is_unique_k8s_node_required: Whether or not the replicas must be scheduled on separate Kubernetes nodes. Only supported on Kubernetes.
-        :param pulumi.Input[str] k8s_worker_os: OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+        :param pulumi.Input[str] k8s_worker_os: OS type for k8s worker. Valid values: `Linux`, `Windows`.
         :param pulumi.Input[str] name: The name of the service to create.
         :param pulumi.Input[str] parent_domain: The service's parent domain
         :param pulumi.Input[bool] replica_collocation_allowed: Allow replica collocation for the service. If this is set then 2 replicas can be on the same host.
@@ -766,7 +766,7 @@ class _DuploServiceState:
     @pulumi.getter(name="k8sWorkerOs")
     def k8s_worker_os(self) -> Optional[pulumi.Input[str]]:
         """
-        OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+        OS type for k8s worker. Valid values: `Linux`, `Windows`.
         """
         return pulumi.get(self, "k8s_worker_os")
 
@@ -1247,7 +1247,7 @@ class DuploService(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[Union['DuploServiceInitContainerDockerImageArgs', 'DuploServiceInitContainerDockerImageArgsDict']]]] init_container_docker_images: The docker images to use for the launched init container(s).
         :param pulumi.Input[bool] is_daemonset: Whether or not to enable DaemonSet.
         :param pulumi.Input[bool] is_unique_k8s_node_required: Whether or not the replicas must be scheduled on separate Kubernetes nodes. Only supported on Kubernetes.
-        :param pulumi.Input[str] k8s_worker_os: OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+        :param pulumi.Input[str] k8s_worker_os: OS type for k8s worker. Valid values: `Linux`, `Windows`.
         :param pulumi.Input[str] name: The name of the service to create.
         :param pulumi.Input[bool] replica_collocation_allowed: Allow replica collocation for the service. If this is set then 2 replicas can be on the same host.
         :param pulumi.Input[int] replicas: The number of container replicas to deploy.
@@ -1709,7 +1709,7 @@ class DuploService(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[Union['DuploServiceInitContainerDockerImageArgs', 'DuploServiceInitContainerDockerImageArgsDict']]]] init_container_docker_images: The docker images to use for the launched init container(s).
         :param pulumi.Input[bool] is_daemonset: Whether or not to enable DaemonSet.
         :param pulumi.Input[bool] is_unique_k8s_node_required: Whether or not the replicas must be scheduled on separate Kubernetes nodes. Only supported on Kubernetes.
-        :param pulumi.Input[str] k8s_worker_os: OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+        :param pulumi.Input[str] k8s_worker_os: OS type for k8s worker. Valid values: `Linux`, `Windows`.
         :param pulumi.Input[str] name: The name of the service to create.
         :param pulumi.Input[str] parent_domain: The service's parent domain
         :param pulumi.Input[bool] replica_collocation_allowed: Allow replica collocation for the service. If this is set then 2 replicas can be on the same host.
@@ -1903,7 +1903,7 @@ class DuploService(pulumi.CustomResource):
     @pulumi.getter(name="k8sWorkerOs")
     def k8s_worker_os(self) -> pulumi.Output[Optional[str]]:
         """
-        OS type for k8s worker, this field is associated to azure cloud. Valid values: `Linux`, `Windows`
+        OS type for k8s worker. Valid values: `Linux`, `Windows`.
         """
         return pulumi.get(self, "k8s_worker_os")
 

--- a/sdk/python/pulumi_duplocloud/get_duplo_service.py
+++ b/sdk/python/pulumi_duplocloud/get_duplo_service.py
@@ -27,7 +27,7 @@ class GetDuploServiceResult:
     """
     A collection of values returned by getDuploService.
     """
-    def __init__(__self__, agent_platform=None, allocation_tags=None, any_host_allowed=None, cloud=None, cloud_creds_from_k8s_service_account=None, commands=None, docker_image=None, domain=None, extra_config=None, force_stateful_set=None, fqdn=None, fqdn_ex=None, hpa_specs=None, id=None, is_daemonset=None, is_unique_k8s_node_required=None, lb_synced_deployment=None, name=None, other_docker_config=None, other_docker_host_config=None, parent_domain=None, replica_collocation_allowed=None, replicas=None, replicas_matching_asg_name=None, should_spread_across_zones=None, tags=None, tenant_id=None, volumes=None):
+    def __init__(__self__, agent_platform=None, allocation_tags=None, any_host_allowed=None, cloud=None, cloud_creds_from_k8s_service_account=None, commands=None, docker_image=None, domain=None, extra_config=None, force_stateful_set=None, fqdn=None, fqdn_ex=None, hpa_specs=None, id=None, is_daemonset=None, is_unique_k8s_node_required=None, k8s_worker_os=None, lb_synced_deployment=None, name=None, other_docker_config=None, other_docker_host_config=None, parent_domain=None, replica_collocation_allowed=None, replicas=None, replicas_matching_asg_name=None, should_spread_across_zones=None, tags=None, tenant_id=None, volumes=None):
         if agent_platform and not isinstance(agent_platform, int):
             raise TypeError("Expected argument 'agent_platform' to be a int")
         pulumi.set(__self__, "agent_platform", agent_platform)
@@ -76,6 +76,9 @@ class GetDuploServiceResult:
         if is_unique_k8s_node_required and not isinstance(is_unique_k8s_node_required, bool):
             raise TypeError("Expected argument 'is_unique_k8s_node_required' to be a bool")
         pulumi.set(__self__, "is_unique_k8s_node_required", is_unique_k8s_node_required)
+        if k8s_worker_os and not isinstance(k8s_worker_os, str):
+            raise TypeError("Expected argument 'k8s_worker_os' to be a str")
+        pulumi.set(__self__, "k8s_worker_os", k8s_worker_os)
         if lb_synced_deployment and not isinstance(lb_synced_deployment, bool):
             raise TypeError("Expected argument 'lb_synced_deployment' to be a bool")
         pulumi.set(__self__, "lb_synced_deployment", lb_synced_deployment)
@@ -209,6 +212,14 @@ class GetDuploServiceResult:
         return pulumi.get(self, "is_unique_k8s_node_required")
 
     @property
+    @pulumi.getter(name="k8sWorkerOs")
+    def k8s_worker_os(self) -> str:
+        """
+        OS type for k8s worker. Valid values: `Linux`, `Windows`.
+        """
+        return pulumi.get(self, "k8s_worker_os")
+
+    @property
     @pulumi.getter(name="lbSyncedDeployment")
     def lb_synced_deployment(self) -> bool:
         return pulumi.get(self, "lb_synced_deployment")
@@ -297,6 +308,7 @@ class AwaitableGetDuploServiceResult(GetDuploServiceResult):
             id=self.id,
             is_daemonset=self.is_daemonset,
             is_unique_k8s_node_required=self.is_unique_k8s_node_required,
+            k8s_worker_os=self.k8s_worker_os,
             lb_synced_deployment=self.lb_synced_deployment,
             name=self.name,
             other_docker_config=self.other_docker_config,
@@ -340,6 +352,7 @@ def get_duplo_service(name: Optional[str] = None,
         id=pulumi.get(__ret__, 'id'),
         is_daemonset=pulumi.get(__ret__, 'is_daemonset'),
         is_unique_k8s_node_required=pulumi.get(__ret__, 'is_unique_k8s_node_required'),
+        k8s_worker_os=pulumi.get(__ret__, 'k8s_worker_os'),
         lb_synced_deployment=pulumi.get(__ret__, 'lb_synced_deployment'),
         name=pulumi.get(__ret__, 'name'),
         other_docker_config=pulumi.get(__ret__, 'other_docker_config'),
@@ -380,6 +393,7 @@ def get_duplo_service_output(name: Optional[pulumi.Input[str]] = None,
         id=pulumi.get(__response__, 'id'),
         is_daemonset=pulumi.get(__response__, 'is_daemonset'),
         is_unique_k8s_node_required=pulumi.get(__response__, 'is_unique_k8s_node_required'),
+        k8s_worker_os=pulumi.get(__response__, 'k8s_worker_os'),
         lb_synced_deployment=pulumi.get(__response__, 'lb_synced_deployment'),
         name=pulumi.get(__response__, 'name'),
         other_docker_config=pulumi.get(__response__, 'other_docker_config'),

--- a/sdk/python/pulumi_duplocloud/outputs.py
+++ b/sdk/python/pulumi_duplocloud/outputs.py
@@ -44739,6 +44739,7 @@ class GetDuploServicesServiceResult(dict):
                  hpa_specs: str,
                  is_daemonset: bool,
                  is_unique_k8s_node_required: bool,
+                 k8s_worker_os: str,
                  lb_synced_deployment: bool,
                  name: str,
                  other_docker_config: str,
@@ -44756,6 +44757,7 @@ class GetDuploServicesServiceResult(dict):
         :param str fqdn: The fully qualified domain associated with the service
         :param str fqdn_ex: External fully qualified domain associated with the service
         :param bool is_unique_k8s_node_required: Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
+        :param str k8s_worker_os: OS type for k8s worker. Valid values: `Linux`, `Windows`.
         :param str parent_domain: The service's parent domain
         :param bool should_spread_across_zones: Whether or not the replicas must be spread across availability zones.  Only supported on Kubernetes.
         """
@@ -44774,6 +44776,7 @@ class GetDuploServicesServiceResult(dict):
         pulumi.set(__self__, "hpa_specs", hpa_specs)
         pulumi.set(__self__, "is_daemonset", is_daemonset)
         pulumi.set(__self__, "is_unique_k8s_node_required", is_unique_k8s_node_required)
+        pulumi.set(__self__, "k8s_worker_os", k8s_worker_os)
         pulumi.set(__self__, "lb_synced_deployment", lb_synced_deployment)
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "other_docker_config", other_docker_config)
@@ -44873,6 +44876,14 @@ class GetDuploServicesServiceResult(dict):
         Whether or not the replicas must be scheduled on separate Kubernetes nodes.  Only supported on Kubernetes.
         """
         return pulumi.get(self, "is_unique_k8s_node_required")
+
+    @property
+    @pulumi.getter(name="k8sWorkerOs")
+    def k8s_worker_os(self) -> str:
+        """
+        OS type for k8s worker. Valid values: `Linux`, `Windows`.
+        """
+        return pulumi.get(self, "k8s_worker_os")
 
     @property
     @pulumi.getter(name="lbSyncedDeployment")


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider duplocloud/pulumi-duplocloud --kind=provider --target-bridge-version=latest --target-version=0.12.15 --allow-missing-docs=true`.

---

- Upgrading terraform-provider-duplocloud from 0.12.14  to 0.12.15.
	Fixes #50
