### PR TITLE
Upgrade terraform-provider-duplocloud to v0.12.16

### DIFF
--- a/provider/cmd/pulumi-resource-duplocloud/schema.json
+++ b/provider/cmd/pulumi-resource-duplocloud/schema.json
@@ -151,7 +151,7 @@
                 },
                 "onDemandPercentageAboveBaseCapacity": {
                     "type": "integer",
-                    "description": "Percentage of On-Demand instances above the base capacity (0-100).\n"
+                    "description": "Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.\n"
                 },
                 "spotAllocationStrategy": {
                     "type": "string",
@@ -5875,6 +5875,10 @@
                     "type": "integer",
                     "description": "Number of Load Balancer target group to associate with the service.\n"
                 },
+                "tcpIdleTimeoutSeconds": {
+                    "type": "integer",
+                    "description": "The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.\n"
+                },
                 "webaclid": {
                     "type": "string",
                     "description": "The ARN of a web application firewall to associate this load balancer.\n"
@@ -5906,6 +5910,7 @@
                         "protocol",
                         "replicationControllerName",
                         "targetGroupCount",
+                        "tcpIdleTimeoutSeconds",
                         "webaclid"
                     ]
                 }
@@ -17402,14 +17407,23 @@
                 },
                 "secondsUntilAutoPause": {
                     "type": "integer",
-                    "description": "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).\n"
+                    "description": "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.\n"
                 }
             },
             "type": "object",
             "required": [
                 "maxCapacity",
                 "minCapacity"
-            ]
+            ],
+            "language": {
+                "nodejs": {
+                    "requiredOutputs": [
+                        "maxCapacity",
+                        "minCapacity",
+                        "secondsUntilAutoPause"
+                    ]
+                }
+            }
         },
         "duplocloud:index/RdsReadReplicaPerformanceInsights:RdsReadReplicaPerformanceInsights": {
             "properties": {
@@ -18029,7 +18043,7 @@
                 },
                 "onDemandPercentageAboveBaseCapacity": {
                     "type": "integer",
-                    "description": "Percentage of On-Demand instances above the base capacity (0-100).\n"
+                    "description": "Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.\n"
                 },
                 "spotAllocationStrategy": {
                     "type": "string",
@@ -19440,6 +19454,10 @@
                     "type": "integer",
                     "description": "Number of Load Balancer target group to associate with the service.\n"
                 },
+                "tcpIdleTimeoutSeconds": {
+                    "type": "integer",
+                    "description": "The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.\n"
+                },
                 "webaclid": {
                     "type": "string",
                     "description": "The ARN of a web application firewall to associate this load balancer.\n"
@@ -19466,6 +19484,7 @@
                 "protocol",
                 "replicationControllerName",
                 "targetGroupCount",
+                "tcpIdleTimeoutSeconds",
                 "webaclid"
             ],
             "language": {
@@ -19836,6 +19855,10 @@
                     "type": "integer",
                     "description": "Number of Load Balancer target group to associate with the service.\n"
                 },
+                "tcpIdleTimeoutSeconds": {
+                    "type": "integer",
+                    "description": "The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.\n"
+                },
                 "webaclid": {
                     "type": "string",
                     "description": "The ARN of a web application firewall to associate this load balancer.\n"
@@ -19862,6 +19885,7 @@
                 "protocol",
                 "replicationControllerName",
                 "targetGroupCount",
+                "tcpIdleTimeoutSeconds",
                 "webaclid"
             ],
             "language": {

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250124205414-92ccb3765401
 
 require (
-	github.com/duplocloud/terraform-provider-duplocloud v0.12.15
+	github.com/duplocloud/terraform-provider-duplocloud v0.12.16
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.102.0
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1522,8 +1522,8 @@ github.com/deckarep/golang-set/v2 v2.5.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpO
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/duplocloud/terraform-provider-duplocloud v0.12.15 h1:6VVJAPihzXIhbaEqEM9aT8Ndw2ccLknaKHekcCuMjEE=
-github.com/duplocloud/terraform-provider-duplocloud v0.12.15/go.mod h1:5pUbnUCoHbmqmkN3i1FYTI0G0XLJxNf5TOKWET8yxns=
+github.com/duplocloud/terraform-provider-duplocloud v0.12.16 h1:vZDt6NxH6JODw1iPEDjCbAvAti5xFE/kTvmH5U3+Rzg=
+github.com/duplocloud/terraform-provider-duplocloud v0.12.16/go.mod h1:5pUbnUCoHbmqmkN3i1FYTI0G0XLJxNf5TOKWET8yxns=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=

--- a/sdk/dotnet/Inputs/AsgProfileMixedInstancesPolicyInstancesDistributionArgs.cs
+++ b/sdk/dotnet/Inputs/AsgProfileMixedInstancesPolicyInstancesDistributionArgs.cs
@@ -26,7 +26,7 @@ namespace DuploCloud.Pulumi.Inputs
         public Input<int>? OnDemandBaseCapacity { get; set; }
 
         /// <summary>
-        /// Percentage of On-Demand instances above the base capacity (0-100).
+        /// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         /// </summary>
         [Input("onDemandPercentageAboveBaseCapacity")]
         public Input<int>? OnDemandPercentageAboveBaseCapacity { get; set; }

--- a/sdk/dotnet/Inputs/AsgProfileMixedInstancesPolicyInstancesDistributionGetArgs.cs
+++ b/sdk/dotnet/Inputs/AsgProfileMixedInstancesPolicyInstancesDistributionGetArgs.cs
@@ -26,7 +26,7 @@ namespace DuploCloud.Pulumi.Inputs
         public Input<int>? OnDemandBaseCapacity { get; set; }
 
         /// <summary>
-        /// Percentage of On-Demand instances above the base capacity (0-100).
+        /// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         /// </summary>
         [Input("onDemandPercentageAboveBaseCapacity")]
         public Input<int>? OnDemandPercentageAboveBaseCapacity { get; set; }

--- a/sdk/dotnet/Inputs/EcsServiceLoadBalancerArgs.cs
+++ b/sdk/dotnet/Inputs/EcsServiceLoadBalancerArgs.cs
@@ -131,6 +131,12 @@ namespace DuploCloud.Pulumi.Inputs
         public Input<int> TargetGroupCount { get; set; } = null!;
 
         /// <summary>
+        /// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+        /// </summary>
+        [Input("tcpIdleTimeoutSeconds")]
+        public Input<int>? TcpIdleTimeoutSeconds { get; set; }
+
+        /// <summary>
         /// The ARN of a web application firewall to associate this load balancer.
         /// </summary>
         [Input("webaclid")]

--- a/sdk/dotnet/Inputs/EcsServiceLoadBalancerGetArgs.cs
+++ b/sdk/dotnet/Inputs/EcsServiceLoadBalancerGetArgs.cs
@@ -131,6 +131,12 @@ namespace DuploCloud.Pulumi.Inputs
         public Input<int> TargetGroupCount { get; set; } = null!;
 
         /// <summary>
+        /// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+        /// </summary>
+        [Input("tcpIdleTimeoutSeconds")]
+        public Input<int>? TcpIdleTimeoutSeconds { get; set; }
+
+        /// <summary>
         /// The ARN of a web application firewall to associate this load balancer.
         /// </summary>
         [Input("webaclid")]

--- a/sdk/dotnet/Inputs/RdsInstanceV2ScalingConfigurationArgs.cs
+++ b/sdk/dotnet/Inputs/RdsInstanceV2ScalingConfigurationArgs.cs
@@ -26,7 +26,7 @@ namespace DuploCloud.Pulumi.Inputs
         public Input<double> MinCapacity { get; set; } = null!;
 
         /// <summary>
-        /// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+        /// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
         /// </summary>
         [Input("secondsUntilAutoPause")]
         public Input<int>? SecondsUntilAutoPause { get; set; }

--- a/sdk/dotnet/Inputs/RdsInstanceV2ScalingConfigurationGetArgs.cs
+++ b/sdk/dotnet/Inputs/RdsInstanceV2ScalingConfigurationGetArgs.cs
@@ -26,7 +26,7 @@ namespace DuploCloud.Pulumi.Inputs
         public Input<double> MinCapacity { get; set; } = null!;
 
         /// <summary>
-        /// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+        /// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
         /// </summary>
         [Input("secondsUntilAutoPause")]
         public Input<int>? SecondsUntilAutoPause { get; set; }

--- a/sdk/dotnet/Outputs/AsgProfileMixedInstancesPolicyInstancesDistribution.cs
+++ b/sdk/dotnet/Outputs/AsgProfileMixedInstancesPolicyInstancesDistribution.cs
@@ -23,7 +23,7 @@ namespace DuploCloud.Pulumi.Outputs
         /// </summary>
         public readonly int? OnDemandBaseCapacity;
         /// <summary>
-        /// Percentage of On-Demand instances above the base capacity (0-100).
+        /// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         /// </summary>
         public readonly int? OnDemandPercentageAboveBaseCapacity;
         /// <summary>

--- a/sdk/dotnet/Outputs/EcsServiceLoadBalancer.cs
+++ b/sdk/dotnet/Outputs/EcsServiceLoadBalancer.cs
@@ -94,6 +94,10 @@ namespace DuploCloud.Pulumi.Outputs
         /// </summary>
         public readonly int TargetGroupCount;
         /// <summary>
+        /// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+        /// </summary>
+        public readonly int? TcpIdleTimeoutSeconds;
+        /// <summary>
         /// The ARN of a web application firewall to associate this load balancer.
         /// </summary>
         public readonly string? Webaclid;
@@ -138,6 +142,8 @@ namespace DuploCloud.Pulumi.Outputs
 
             int targetGroupCount,
 
+            int? tcpIdleTimeoutSeconds,
+
             string? webaclid)
         {
             BackendProtocol = backendProtocol;
@@ -159,6 +165,7 @@ namespace DuploCloud.Pulumi.Outputs
             Protocol = protocol;
             ReplicationControllerName = replicationControllerName;
             TargetGroupCount = targetGroupCount;
+            TcpIdleTimeoutSeconds = tcpIdleTimeoutSeconds;
             Webaclid = webaclid;
         }
     }

--- a/sdk/dotnet/Outputs/GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistributionResult.cs
+++ b/sdk/dotnet/Outputs/GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistributionResult.cs
@@ -23,7 +23,7 @@ namespace DuploCloud.Pulumi.Outputs
         /// </summary>
         public readonly int? OnDemandBaseCapacity;
         /// <summary>
-        /// Percentage of On-Demand instances above the base capacity (0-100).
+        /// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         /// </summary>
         public readonly int? OnDemandPercentageAboveBaseCapacity;
         /// <summary>

--- a/sdk/dotnet/Outputs/GetEcsServiceLoadBalancerResult.cs
+++ b/sdk/dotnet/Outputs/GetEcsServiceLoadBalancerResult.cs
@@ -94,6 +94,10 @@ namespace DuploCloud.Pulumi.Outputs
         /// </summary>
         public readonly int TargetGroupCount;
         /// <summary>
+        /// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+        /// </summary>
+        public readonly int TcpIdleTimeoutSeconds;
+        /// <summary>
         /// The ARN of a web application firewall to associate this load balancer.
         /// </summary>
         public readonly string Webaclid;
@@ -138,6 +142,8 @@ namespace DuploCloud.Pulumi.Outputs
 
             int targetGroupCount,
 
+            int tcpIdleTimeoutSeconds,
+
             string webaclid)
         {
             BackendProtocol = backendProtocol;
@@ -159,6 +165,7 @@ namespace DuploCloud.Pulumi.Outputs
             Protocol = protocol;
             ReplicationControllerName = replicationControllerName;
             TargetGroupCount = targetGroupCount;
+            TcpIdleTimeoutSeconds = tcpIdleTimeoutSeconds;
             Webaclid = webaclid;
         }
     }

--- a/sdk/dotnet/Outputs/GetEcsServicesServiceLoadBalancerResult.cs
+++ b/sdk/dotnet/Outputs/GetEcsServicesServiceLoadBalancerResult.cs
@@ -94,6 +94,10 @@ namespace DuploCloud.Pulumi.Outputs
         /// </summary>
         public readonly int TargetGroupCount;
         /// <summary>
+        /// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+        /// </summary>
+        public readonly int TcpIdleTimeoutSeconds;
+        /// <summary>
         /// The ARN of a web application firewall to associate this load balancer.
         /// </summary>
         public readonly string Webaclid;
@@ -138,6 +142,8 @@ namespace DuploCloud.Pulumi.Outputs
 
             int targetGroupCount,
 
+            int tcpIdleTimeoutSeconds,
+
             string webaclid)
         {
             BackendProtocol = backendProtocol;
@@ -159,6 +165,7 @@ namespace DuploCloud.Pulumi.Outputs
             Protocol = protocol;
             ReplicationControllerName = replicationControllerName;
             TargetGroupCount = targetGroupCount;
+            TcpIdleTimeoutSeconds = tcpIdleTimeoutSeconds;
             Webaclid = webaclid;
         }
     }

--- a/sdk/dotnet/Outputs/RdsInstanceV2ScalingConfiguration.cs
+++ b/sdk/dotnet/Outputs/RdsInstanceV2ScalingConfiguration.cs
@@ -23,7 +23,7 @@ namespace DuploCloud.Pulumi.Outputs
         /// </summary>
         public readonly double MinCapacity;
         /// <summary>
-        /// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+        /// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
         /// </summary>
         public readonly int? SecondsUntilAutoPause;
 

--- a/sdk/go/duplocloud/pulumiTypes.go
+++ b/sdk/go/duplocloud/pulumiTypes.go
@@ -478,7 +478,7 @@ type AsgProfileMixedInstancesPolicyInstancesDistribution struct {
 	OnDemandAllocationStrategy *string `pulumi:"onDemandAllocationStrategy"`
 	// Minimum number of On-Demand instances in the group.
 	OnDemandBaseCapacity *int `pulumi:"onDemandBaseCapacity"`
-	// Percentage of On-Demand instances above the base capacity (0-100).
+	// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
 	OnDemandPercentageAboveBaseCapacity *int `pulumi:"onDemandPercentageAboveBaseCapacity"`
 	// Strategy for allocating Spot instances (e.g. `capacity-optimized`, `price-capacity-optimized`, `lowest-price`).
 	SpotAllocationStrategy *string `pulumi:"spotAllocationStrategy"`
@@ -504,7 +504,7 @@ type AsgProfileMixedInstancesPolicyInstancesDistributionArgs struct {
 	OnDemandAllocationStrategy pulumi.StringPtrInput `pulumi:"onDemandAllocationStrategy"`
 	// Minimum number of On-Demand instances in the group.
 	OnDemandBaseCapacity pulumi.IntPtrInput `pulumi:"onDemandBaseCapacity"`
-	// Percentage of On-Demand instances above the base capacity (0-100).
+	// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
 	OnDemandPercentageAboveBaseCapacity pulumi.IntPtrInput `pulumi:"onDemandPercentageAboveBaseCapacity"`
 	// Strategy for allocating Spot instances (e.g. `capacity-optimized`, `price-capacity-optimized`, `lowest-price`).
 	SpotAllocationStrategy pulumi.StringPtrInput `pulumi:"spotAllocationStrategy"`
@@ -603,7 +603,7 @@ func (o AsgProfileMixedInstancesPolicyInstancesDistributionOutput) OnDemandBaseC
 	return o.ApplyT(func(v AsgProfileMixedInstancesPolicyInstancesDistribution) *int { return v.OnDemandBaseCapacity }).(pulumi.IntPtrOutput)
 }
 
-// Percentage of On-Demand instances above the base capacity (0-100).
+// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
 func (o AsgProfileMixedInstancesPolicyInstancesDistributionOutput) OnDemandPercentageAboveBaseCapacity() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v AsgProfileMixedInstancesPolicyInstancesDistribution) *int {
 		return v.OnDemandPercentageAboveBaseCapacity
@@ -669,7 +669,7 @@ func (o AsgProfileMixedInstancesPolicyInstancesDistributionPtrOutput) OnDemandBa
 	}).(pulumi.IntPtrOutput)
 }
 
-// Percentage of On-Demand instances above the base capacity (0-100).
+// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
 func (o AsgProfileMixedInstancesPolicyInstancesDistributionPtrOutput) OnDemandPercentageAboveBaseCapacity() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *AsgProfileMixedInstancesPolicyInstancesDistribution) *int {
 		if v == nil {
@@ -32959,6 +32959,8 @@ type EcsServiceLoadBalancer struct {
 	ReplicationControllerName *string `pulumi:"replicationControllerName"`
 	// Number of Load Balancer target group to associate with the service.
 	TargetGroupCount int `pulumi:"targetGroupCount"`
+	// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+	TcpIdleTimeoutSeconds *int `pulumi:"tcpIdleTimeoutSeconds"`
 	// The ARN of a web application firewall to associate this load balancer.
 	Webaclid *string `pulumi:"webaclid"`
 }
@@ -33020,6 +33022,8 @@ type EcsServiceLoadBalancerArgs struct {
 	ReplicationControllerName pulumi.StringPtrInput `pulumi:"replicationControllerName"`
 	// Number of Load Balancer target group to associate with the service.
 	TargetGroupCount pulumi.IntInput `pulumi:"targetGroupCount"`
+	// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+	TcpIdleTimeoutSeconds pulumi.IntPtrInput `pulumi:"tcpIdleTimeoutSeconds"`
 	// The ARN of a web application firewall to associate this load balancer.
 	Webaclid pulumi.StringPtrInput `pulumi:"webaclid"`
 }
@@ -33175,6 +33179,11 @@ func (o EcsServiceLoadBalancerOutput) ReplicationControllerName() pulumi.StringP
 // Number of Load Balancer target group to associate with the service.
 func (o EcsServiceLoadBalancerOutput) TargetGroupCount() pulumi.IntOutput {
 	return o.ApplyT(func(v EcsServiceLoadBalancer) int { return v.TargetGroupCount }).(pulumi.IntOutput)
+}
+
+// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+func (o EcsServiceLoadBalancerOutput) TcpIdleTimeoutSeconds() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v EcsServiceLoadBalancer) *int { return v.TcpIdleTimeoutSeconds }).(pulumi.IntPtrOutput)
 }
 
 // The ARN of a web application firewall to associate this load balancer.

--- a/sdk/go/duplocloud/pulumiTypes1.go
+++ b/sdk/go/duplocloud/pulumiTypes1.go
@@ -28306,7 +28306,7 @@ type RdsInstanceV2ScalingConfiguration struct {
 	MaxCapacity float64 `pulumi:"maxCapacity"`
 	// Specifies min scaling capacity. Set to `0` to enable Aurora Serverless v2 auto-pause (scale to zero) for idle clusters.
 	MinCapacity float64 `pulumi:"minCapacity"`
-	// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+	// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
 	SecondsUntilAutoPause *int `pulumi:"secondsUntilAutoPause"`
 }
 
@@ -28326,7 +28326,7 @@ type RdsInstanceV2ScalingConfigurationArgs struct {
 	MaxCapacity pulumi.Float64Input `pulumi:"maxCapacity"`
 	// Specifies min scaling capacity. Set to `0` to enable Aurora Serverless v2 auto-pause (scale to zero) for idle clusters.
 	MinCapacity pulumi.Float64Input `pulumi:"minCapacity"`
-	// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+	// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
 	SecondsUntilAutoPause pulumi.IntPtrInput `pulumi:"secondsUntilAutoPause"`
 }
 
@@ -28417,7 +28417,7 @@ func (o RdsInstanceV2ScalingConfigurationOutput) MinCapacity() pulumi.Float64Out
 	return o.ApplyT(func(v RdsInstanceV2ScalingConfiguration) float64 { return v.MinCapacity }).(pulumi.Float64Output)
 }
 
-// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
 func (o RdsInstanceV2ScalingConfigurationOutput) SecondsUntilAutoPause() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v RdsInstanceV2ScalingConfiguration) *int { return v.SecondsUntilAutoPause }).(pulumi.IntPtrOutput)
 }
@@ -28466,7 +28466,7 @@ func (o RdsInstanceV2ScalingConfigurationPtrOutput) MinCapacity() pulumi.Float64
 	}).(pulumi.Float64PtrOutput)
 }
 
-// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+// The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
 func (o RdsInstanceV2ScalingConfigurationPtrOutput) SecondsUntilAutoPause() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *RdsInstanceV2ScalingConfiguration) *int {
 		if v == nil {
@@ -31179,7 +31179,7 @@ type GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistribution struct {
 	OnDemandAllocationStrategy string `pulumi:"onDemandAllocationStrategy"`
 	// Minimum number of On-Demand instances in the group.
 	OnDemandBaseCapacity *int `pulumi:"onDemandBaseCapacity"`
-	// Percentage of On-Demand instances above the base capacity (0-100).
+	// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
 	OnDemandPercentageAboveBaseCapacity *int `pulumi:"onDemandPercentageAboveBaseCapacity"`
 	// Strategy for allocating Spot instances (e.g. `capacity-optimized`, `price-capacity-optimized`, `lowest-price`).
 	SpotAllocationStrategy *string `pulumi:"spotAllocationStrategy"`
@@ -31205,7 +31205,7 @@ type GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistributionArgs struc
 	OnDemandAllocationStrategy pulumi.StringInput `pulumi:"onDemandAllocationStrategy"`
 	// Minimum number of On-Demand instances in the group.
 	OnDemandBaseCapacity pulumi.IntPtrInput `pulumi:"onDemandBaseCapacity"`
-	// Percentage of On-Demand instances above the base capacity (0-100).
+	// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
 	OnDemandPercentageAboveBaseCapacity pulumi.IntPtrInput `pulumi:"onDemandPercentageAboveBaseCapacity"`
 	// Strategy for allocating Spot instances (e.g. `capacity-optimized`, `price-capacity-optimized`, `lowest-price`).
 	SpotAllocationStrategy pulumi.StringPtrInput `pulumi:"spotAllocationStrategy"`
@@ -31306,7 +31306,7 @@ func (o GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistributionOutput)
 	}).(pulumi.IntPtrOutput)
 }
 
-// Percentage of On-Demand instances above the base capacity (0-100).
+// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
 func (o GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistributionOutput) OnDemandPercentageAboveBaseCapacity() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistribution) *int {
 		return v.OnDemandPercentageAboveBaseCapacity
@@ -31378,7 +31378,7 @@ func (o GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistributionPtrOutp
 	}).(pulumi.IntPtrOutput)
 }
 
-// Percentage of On-Demand instances above the base capacity (0-100).
+// Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
 func (o GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistributionPtrOutput) OnDemandPercentageAboveBaseCapacity() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistribution) *int {
 		if v == nil {
@@ -36272,6 +36272,8 @@ type GetEcsServiceLoadBalancer struct {
 	ReplicationControllerName string `pulumi:"replicationControllerName"`
 	// Number of Load Balancer target group to associate with the service.
 	TargetGroupCount int `pulumi:"targetGroupCount"`
+	// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+	TcpIdleTimeoutSeconds int `pulumi:"tcpIdleTimeoutSeconds"`
 	// The ARN of a web application firewall to associate this load balancer.
 	Webaclid string `pulumi:"webaclid"`
 }
@@ -36333,6 +36335,8 @@ type GetEcsServiceLoadBalancerArgs struct {
 	ReplicationControllerName pulumi.StringInput `pulumi:"replicationControllerName"`
 	// Number of Load Balancer target group to associate with the service.
 	TargetGroupCount pulumi.IntInput `pulumi:"targetGroupCount"`
+	// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+	TcpIdleTimeoutSeconds pulumi.IntInput `pulumi:"tcpIdleTimeoutSeconds"`
 	// The ARN of a web application firewall to associate this load balancer.
 	Webaclid pulumi.StringInput `pulumi:"webaclid"`
 }
@@ -36490,6 +36494,11 @@ func (o GetEcsServiceLoadBalancerOutput) ReplicationControllerName() pulumi.Stri
 // Number of Load Balancer target group to associate with the service.
 func (o GetEcsServiceLoadBalancerOutput) TargetGroupCount() pulumi.IntOutput {
 	return o.ApplyT(func(v GetEcsServiceLoadBalancer) int { return v.TargetGroupCount }).(pulumi.IntOutput)
+}
+
+// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+func (o GetEcsServiceLoadBalancerOutput) TcpIdleTimeoutSeconds() pulumi.IntOutput {
+	return o.ApplyT(func(v GetEcsServiceLoadBalancer) int { return v.TcpIdleTimeoutSeconds }).(pulumi.IntOutput)
 }
 
 // The ARN of a web application firewall to associate this load balancer.
@@ -37493,6 +37502,8 @@ type GetEcsServicesServiceLoadBalancer struct {
 	ReplicationControllerName string `pulumi:"replicationControllerName"`
 	// Number of Load Balancer target group to associate with the service.
 	TargetGroupCount int `pulumi:"targetGroupCount"`
+	// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+	TcpIdleTimeoutSeconds int `pulumi:"tcpIdleTimeoutSeconds"`
 	// The ARN of a web application firewall to associate this load balancer.
 	Webaclid string `pulumi:"webaclid"`
 }
@@ -37554,6 +37565,8 @@ type GetEcsServicesServiceLoadBalancerArgs struct {
 	ReplicationControllerName pulumi.StringInput `pulumi:"replicationControllerName"`
 	// Number of Load Balancer target group to associate with the service.
 	TargetGroupCount pulumi.IntInput `pulumi:"targetGroupCount"`
+	// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+	TcpIdleTimeoutSeconds pulumi.IntInput `pulumi:"tcpIdleTimeoutSeconds"`
 	// The ARN of a web application firewall to associate this load balancer.
 	Webaclid pulumi.StringInput `pulumi:"webaclid"`
 }
@@ -37711,6 +37724,11 @@ func (o GetEcsServicesServiceLoadBalancerOutput) ReplicationControllerName() pul
 // Number of Load Balancer target group to associate with the service.
 func (o GetEcsServicesServiceLoadBalancerOutput) TargetGroupCount() pulumi.IntOutput {
 	return o.ApplyT(func(v GetEcsServicesServiceLoadBalancer) int { return v.TargetGroupCount }).(pulumi.IntOutput)
+}
+
+// The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+func (o GetEcsServicesServiceLoadBalancerOutput) TcpIdleTimeoutSeconds() pulumi.IntOutput {
+	return o.ApplyT(func(v GetEcsServicesServiceLoadBalancer) int { return v.TcpIdleTimeoutSeconds }).(pulumi.IntOutput)
 }
 
 // The ARN of a web application firewall to associate this load balancer.

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -41,7 +41,7 @@ export interface AsgProfileMixedInstancesPolicyInstancesDistribution {
      */
     onDemandBaseCapacity?: pulumi.Input<number>;
     /**
-     * Percentage of On-Demand instances above the base capacity (0-100).
+     * Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
      */
     onDemandPercentageAboveBaseCapacity?: pulumi.Input<number>;
     /**
@@ -2962,6 +2962,10 @@ export interface EcsServiceLoadBalancer {
      * Number of Load Balancer target group to associate with the service.
      */
     targetGroupCount: pulumi.Input<number>;
+    /**
+     * The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+     */
+    tcpIdleTimeoutSeconds?: pulumi.Input<number>;
     /**
      * The ARN of a web application firewall to associate this load balancer.
      */
@@ -10765,7 +10769,7 @@ export interface RdsInstanceV2ScalingConfiguration {
      */
     minCapacity: pulumi.Input<number>;
     /**
-     * The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+     * The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
      */
     secondsUntilAutoPause?: pulumi.Input<number>;
 }

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -41,7 +41,7 @@ export interface AsgProfileMixedInstancesPolicyInstancesDistribution {
      */
     onDemandBaseCapacity?: number;
     /**
-     * Percentage of On-Demand instances above the base capacity (0-100).
+     * Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
      */
     onDemandPercentageAboveBaseCapacity?: number;
     /**
@@ -2963,6 +2963,10 @@ export interface EcsServiceLoadBalancer {
      */
     targetGroupCount: number;
     /**
+     * The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+     */
+    tcpIdleTimeoutSeconds: number;
+    /**
      * The ARN of a web application firewall to associate this load balancer.
      */
     webaclid: string;
@@ -3727,7 +3731,7 @@ export interface GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistributi
      */
     onDemandBaseCapacity?: number;
     /**
-     * Percentage of On-Demand instances above the base capacity (0-100).
+     * Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
      */
     onDemandPercentageAboveBaseCapacity?: number;
     /**
@@ -4435,6 +4439,10 @@ export interface GetEcsServiceLoadBalancer {
      */
     targetGroupCount: number;
     /**
+     * The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+     */
+    tcpIdleTimeoutSeconds: number;
+    /**
      * The ARN of a web application firewall to associate this load balancer.
      */
     webaclid: string;
@@ -4658,6 +4666,10 @@ export interface GetEcsServicesServiceLoadBalancer {
      * Number of Load Balancer target group to associate with the service.
      */
     targetGroupCount: number;
+    /**
+     * The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lbType = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+     */
+    tcpIdleTimeoutSeconds: number;
     /**
      * The ARN of a web application firewall to associate this load balancer.
      */
@@ -19343,9 +19355,9 @@ export interface RdsInstanceV2ScalingConfiguration {
      */
     minCapacity: number;
     /**
-     * The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+     * The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `minCapacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `minCapacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
      */
-    secondsUntilAutoPause?: number;
+    secondsUntilAutoPause: number;
 }
 
 export interface RdsReadReplicaPerformanceInsights {

--- a/sdk/python/pulumi_duplocloud/_inputs.py
+++ b/sdk/python/pulumi_duplocloud/_inputs.py
@@ -1589,7 +1589,7 @@ if not MYPY:
         """
         on_demand_percentage_above_base_capacity: NotRequired[pulumi.Input[int]]
         """
-        Percentage of On-Demand instances above the base capacity (0-100).
+        Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         """
         spot_allocation_strategy: NotRequired[pulumi.Input[str]]
         """
@@ -1618,7 +1618,7 @@ class AsgProfileMixedInstancesPolicyInstancesDistributionArgs:
         """
         :param pulumi.Input[str] on_demand_allocation_strategy: Strategy for allocating On-Demand instances (e.g. `prioritized`).
         :param pulumi.Input[int] on_demand_base_capacity: Minimum number of On-Demand instances in the group.
-        :param pulumi.Input[int] on_demand_percentage_above_base_capacity: Percentage of On-Demand instances above the base capacity (0-100).
+        :param pulumi.Input[int] on_demand_percentage_above_base_capacity: Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         :param pulumi.Input[str] spot_allocation_strategy: Strategy for allocating Spot instances (e.g. `capacity-optimized`, `price-capacity-optimized`, `lowest-price`).
         :param pulumi.Input[int] spot_instance_pools: Number of Spot pools for allocation (only used with `lowest-price` strategy).
         :param pulumi.Input[str] spot_max_price: Maximum price per unit hour for Spot instances.
@@ -1664,7 +1664,7 @@ class AsgProfileMixedInstancesPolicyInstancesDistributionArgs:
     @pulumi.getter(name="onDemandPercentageAboveBaseCapacity")
     def on_demand_percentage_above_base_capacity(self) -> Optional[pulumi.Input[int]]:
         """
-        Percentage of On-Demand instances above the base capacity (0-100).
+        Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         """
         return pulumi.get(self, "on_demand_percentage_above_base_capacity")
 
@@ -17325,6 +17325,10 @@ if not MYPY:
         The load balancer name.
         """
         replication_controller_name: NotRequired[pulumi.Input[str]]
+        tcp_idle_timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+        """
         webaclid: NotRequired[pulumi.Input[str]]
         """
         The ARN of a web application firewall to associate this load balancer.
@@ -17354,6 +17358,7 @@ class EcsServiceLoadBalancerArgs:
                  load_balancer_arn: Optional[pulumi.Input[str]] = None,
                  load_balancer_name: Optional[pulumi.Input[str]] = None,
                  replication_controller_name: Optional[pulumi.Input[str]] = None,
+                 tcp_idle_timeout_seconds: Optional[pulumi.Input[int]] = None,
                  webaclid: Optional[pulumi.Input[str]] = None):
         """
         :param pulumi.Input[int] external_port: The frontend port associated with this load balancer configuration.
@@ -17380,6 +17385,7 @@ class EcsServiceLoadBalancerArgs:
         :param pulumi.Input[bool] is_internal: Whether or not to create an internal load balancer.
         :param pulumi.Input[str] load_balancer_arn: The load balancer ARN.
         :param pulumi.Input[str] load_balancer_name: The load balancer name.
+        :param pulumi.Input[int] tcp_idle_timeout_seconds: The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
         :param pulumi.Input[str] webaclid: The ARN of a web application firewall to associate this load balancer.
         """
         pulumi.set(__self__, "external_port", external_port)
@@ -17418,6 +17424,8 @@ class EcsServiceLoadBalancerArgs:
             pulumi.set(__self__, "load_balancer_name", load_balancer_name)
         if replication_controller_name is not None:
             pulumi.set(__self__, "replication_controller_name", replication_controller_name)
+        if tcp_idle_timeout_seconds is not None:
+            pulumi.set(__self__, "tcp_idle_timeout_seconds", tcp_idle_timeout_seconds)
         if webaclid is not None:
             pulumi.set(__self__, "webaclid", webaclid)
 
@@ -17652,6 +17660,18 @@ class EcsServiceLoadBalancerArgs:
     @replication_controller_name.setter
     def replication_controller_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "replication_controller_name", value)
+
+    @property
+    @pulumi.getter(name="tcpIdleTimeoutSeconds")
+    def tcp_idle_timeout_seconds(self) -> Optional[pulumi.Input[int]]:
+        """
+        The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+        """
+        return pulumi.get(self, "tcp_idle_timeout_seconds")
+
+    @tcp_idle_timeout_seconds.setter
+    def tcp_idle_timeout_seconds(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "tcp_idle_timeout_seconds", value)
 
     @property
     @pulumi.getter
@@ -54790,7 +54810,7 @@ if not MYPY:
         """
         seconds_until_auto_pause: NotRequired[pulumi.Input[int]]
         """
-        The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+        The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
         """
 elif False:
     RdsInstanceV2ScalingConfigurationArgsDict: TypeAlias = Mapping[str, Any]
@@ -54804,7 +54824,7 @@ class RdsInstanceV2ScalingConfigurationArgs:
         """
         :param pulumi.Input[float] max_capacity: Specifies max scaling capacity.
         :param pulumi.Input[float] min_capacity: Specifies min scaling capacity. Set to `0` to enable Aurora Serverless v2 auto-pause (scale to zero) for idle clusters.
-        :param pulumi.Input[int] seconds_until_auto_pause: The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+        :param pulumi.Input[int] seconds_until_auto_pause: The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
         """
         pulumi.set(__self__, "max_capacity", max_capacity)
         pulumi.set(__self__, "min_capacity", min_capacity)
@@ -54839,7 +54859,7 @@ class RdsInstanceV2ScalingConfigurationArgs:
     @pulumi.getter(name="secondsUntilAutoPause")
     def seconds_until_auto_pause(self) -> Optional[pulumi.Input[int]]:
         """
-        The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+        The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
         """
         return pulumi.get(self, "seconds_until_auto_pause")
 

--- a/sdk/python/pulumi_duplocloud/outputs.py
+++ b/sdk/python/pulumi_duplocloud/outputs.py
@@ -1385,7 +1385,7 @@ class AsgProfileMixedInstancesPolicyInstancesDistribution(dict):
         """
         :param str on_demand_allocation_strategy: Strategy for allocating On-Demand instances (e.g. `prioritized`).
         :param int on_demand_base_capacity: Minimum number of On-Demand instances in the group.
-        :param int on_demand_percentage_above_base_capacity: Percentage of On-Demand instances above the base capacity (0-100).
+        :param int on_demand_percentage_above_base_capacity: Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         :param str spot_allocation_strategy: Strategy for allocating Spot instances (e.g. `capacity-optimized`, `price-capacity-optimized`, `lowest-price`).
         :param int spot_instance_pools: Number of Spot pools for allocation (only used with `lowest-price` strategy).
         :param str spot_max_price: Maximum price per unit hour for Spot instances.
@@ -1423,7 +1423,7 @@ class AsgProfileMixedInstancesPolicyInstancesDistribution(dict):
     @pulumi.getter(name="onDemandPercentageAboveBaseCapacity")
     def on_demand_percentage_above_base_capacity(self) -> Optional[int]:
         """
-        Percentage of On-Demand instances above the base capacity (0-100).
+        Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         """
         return pulumi.get(self, "on_demand_percentage_above_base_capacity")
 
@@ -13912,6 +13912,8 @@ class EcsServiceLoadBalancer(dict):
             suggest = "load_balancer_name"
         elif key == "replicationControllerName":
             suggest = "replication_controller_name"
+        elif key == "tcpIdleTimeoutSeconds":
+            suggest = "tcp_idle_timeout_seconds"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in EcsServiceLoadBalancer. Access the value via the '{suggest}' property getter instead.")
@@ -13944,6 +13946,7 @@ class EcsServiceLoadBalancer(dict):
                  load_balancer_arn: Optional[str] = None,
                  load_balancer_name: Optional[str] = None,
                  replication_controller_name: Optional[str] = None,
+                 tcp_idle_timeout_seconds: Optional[int] = None,
                  webaclid: Optional[str] = None):
         """
         :param int external_port: The frontend port associated with this load balancer configuration.
@@ -13970,6 +13973,7 @@ class EcsServiceLoadBalancer(dict):
         :param bool is_internal: Whether or not to create an internal load balancer.
         :param str load_balancer_arn: The load balancer ARN.
         :param str load_balancer_name: The load balancer name.
+        :param int tcp_idle_timeout_seconds: The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
         :param str webaclid: The ARN of a web application firewall to associate this load balancer.
         """
         pulumi.set(__self__, "external_port", external_port)
@@ -14005,6 +14009,8 @@ class EcsServiceLoadBalancer(dict):
             pulumi.set(__self__, "load_balancer_name", load_balancer_name)
         if replication_controller_name is not None:
             pulumi.set(__self__, "replication_controller_name", replication_controller_name)
+        if tcp_idle_timeout_seconds is not None:
+            pulumi.set(__self__, "tcp_idle_timeout_seconds", tcp_idle_timeout_seconds)
         if webaclid is not None:
             pulumi.set(__self__, "webaclid", webaclid)
 
@@ -14163,6 +14169,14 @@ class EcsServiceLoadBalancer(dict):
     @pulumi.getter(name="replicationControllerName")
     def replication_controller_name(self) -> Optional[str]:
         return pulumi.get(self, "replication_controller_name")
+
+    @property
+    @pulumi.getter(name="tcpIdleTimeoutSeconds")
+    def tcp_idle_timeout_seconds(self) -> Optional[int]:
+        """
+        The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+        """
+        return pulumi.get(self, "tcp_idle_timeout_seconds")
 
     @property
     @pulumi.getter
@@ -41866,7 +41880,7 @@ class RdsInstanceV2ScalingConfiguration(dict):
         """
         :param float max_capacity: Specifies max scaling capacity.
         :param float min_capacity: Specifies min scaling capacity. Set to `0` to enable Aurora Serverless v2 auto-pause (scale to zero) for idle clusters.
-        :param int seconds_until_auto_pause: The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+        :param int seconds_until_auto_pause: The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
         """
         pulumi.set(__self__, "max_capacity", max_capacity)
         pulumi.set(__self__, "min_capacity", min_capacity)
@@ -41893,7 +41907,7 @@ class RdsInstanceV2ScalingConfiguration(dict):
     @pulumi.getter(name="secondsUntilAutoPause")
     def seconds_until_auto_pause(self) -> Optional[int]:
         """
-        The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+        The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
         """
         return pulumi.get(self, "seconds_until_auto_pause")
 
@@ -43070,7 +43084,7 @@ class GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistributionResult(di
         """
         :param str on_demand_allocation_strategy: Strategy for allocating On-Demand instances (e.g. `prioritized`).
         :param int on_demand_base_capacity: Minimum number of On-Demand instances in the group.
-        :param int on_demand_percentage_above_base_capacity: Percentage of On-Demand instances above the base capacity (0-100).
+        :param int on_demand_percentage_above_base_capacity: Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         :param str spot_allocation_strategy: Strategy for allocating Spot instances (e.g. `capacity-optimized`, `price-capacity-optimized`, `lowest-price`).
         :param int spot_instance_pools: Number of Spot pools for allocation (only used with `lowest-price` strategy).
         :param str spot_max_price: Maximum price per unit hour for Spot instances.
@@ -43107,7 +43121,7 @@ class GetAsgProfilesAsgProfileMixedInstancesPolicyInstancesDistributionResult(di
     @pulumi.getter(name="onDemandPercentageAboveBaseCapacity")
     def on_demand_percentage_above_base_capacity(self) -> Optional[int]:
         """
-        Percentage of On-Demand instances above the base capacity (0-100).
+        Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
         """
         return pulumi.get(self, "on_demand_percentage_above_base_capacity")
 
@@ -45137,6 +45151,7 @@ class GetEcsServiceLoadBalancerResult(dict):
                  protocol: str,
                  replication_controller_name: str,
                  target_group_count: int,
+                 tcp_idle_timeout_seconds: int,
                  webaclid: str):
         """
         :param str backend_protocol: The backend protocol associated with this load balancer configuration.
@@ -45163,6 +45178,7 @@ class GetEcsServiceLoadBalancerResult(dict):
         :param str port: The backend port associated with this load balancer configuration.
         :param str protocol: The frontend protocol associated with this load balancer configuration.
         :param int target_group_count: Number of Load Balancer target group to associate with the service.
+        :param int tcp_idle_timeout_seconds: The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
         :param str webaclid: The ARN of a web application firewall to associate this load balancer.
         """
         pulumi.set(__self__, "backend_protocol", backend_protocol)
@@ -45184,6 +45200,7 @@ class GetEcsServiceLoadBalancerResult(dict):
         pulumi.set(__self__, "protocol", protocol)
         pulumi.set(__self__, "replication_controller_name", replication_controller_name)
         pulumi.set(__self__, "target_group_count", target_group_count)
+        pulumi.set(__self__, "tcp_idle_timeout_seconds", tcp_idle_timeout_seconds)
         pulumi.set(__self__, "webaclid", webaclid)
 
     @property
@@ -45341,6 +45358,14 @@ class GetEcsServiceLoadBalancerResult(dict):
         Number of Load Balancer target group to associate with the service.
         """
         return pulumi.get(self, "target_group_count")
+
+    @property
+    @pulumi.getter(name="tcpIdleTimeoutSeconds")
+    def tcp_idle_timeout_seconds(self) -> int:
+        """
+        The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+        """
+        return pulumi.get(self, "tcp_idle_timeout_seconds")
 
     @property
     @pulumi.getter
@@ -45787,6 +45812,7 @@ class GetEcsServicesServiceLoadBalancerResult(dict):
                  protocol: str,
                  replication_controller_name: str,
                  target_group_count: int,
+                 tcp_idle_timeout_seconds: int,
                  webaclid: str):
         """
         :param str backend_protocol: The backend protocol associated with this load balancer configuration.
@@ -45813,6 +45839,7 @@ class GetEcsServicesServiceLoadBalancerResult(dict):
         :param str port: The backend port associated with this load balancer configuration.
         :param str protocol: The frontend protocol associated with this load balancer configuration.
         :param int target_group_count: Number of Load Balancer target group to associate with the service.
+        :param int tcp_idle_timeout_seconds: The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
         :param str webaclid: The ARN of a web application firewall to associate this load balancer.
         """
         pulumi.set(__self__, "backend_protocol", backend_protocol)
@@ -45834,6 +45861,7 @@ class GetEcsServicesServiceLoadBalancerResult(dict):
         pulumi.set(__self__, "protocol", protocol)
         pulumi.set(__self__, "replication_controller_name", replication_controller_name)
         pulumi.set(__self__, "target_group_count", target_group_count)
+        pulumi.set(__self__, "tcp_idle_timeout_seconds", tcp_idle_timeout_seconds)
         pulumi.set(__self__, "webaclid", webaclid)
 
     @property
@@ -45991,6 +46019,14 @@ class GetEcsServicesServiceLoadBalancerResult(dict):
         Number of Load Balancer target group to associate with the service.
         """
         return pulumi.get(self, "target_group_count")
+
+    @property
+    @pulumi.getter(name="tcpIdleTimeoutSeconds")
+    def tcp_idle_timeout_seconds(self) -> int:
+        """
+        The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
+        """
+        return pulumi.get(self, "tcp_idle_timeout_seconds")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider duplocloud/pulumi-duplocloud --kind=provider --target-bridge-version=latest --target-version=0.12.16 --allow-missing-docs=true`.

---

- Upgrading terraform-provider-duplocloud from 0.12.15  to 0.12.16.
	Fixes #52
